### PR TITLE
Remove set-default command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,3 @@ jobs:
       - run: pip install mkdocs-glightbox
       - run: pip install mike
       - run: mike deploy 5.7.1 latest --update-aliases --push -F ./config/en/mkdocs.yml
-      - run: mike set-default latest --push -F ./config/en/mkdocs.yml


### PR DESCRIPTION
Description: This PR removes the set-default command from the github actions file so it does not set 5.7.1 as the default version automatically.