### PR TITLE
Move the changelogs page below tools and customisation

### DIFF
--- a/config/en/mkdocs.yml
+++ b/config/en/mkdocs.yml
@@ -93,7 +93,6 @@ nav:
       - Endpoints: 
           - Waypoint: Server Docs/Endpoints/waypoint.md
   - Tools & Customisation:
-      - Changelogs: Tools and Customisation/changelogs.md
       - Custom Mob Icons: Tools and Customisation/custom-mob-icons.md
       - Integrate your mod: Tools and Customisation/integration.md
       - JourneyMap Tools: Tools and Customisation/journeymap-tools.md
@@ -101,3 +100,4 @@ nav:
       - Topographic: Tools and Customisation/topographic.md
       - Translate: Tools and Customisation/translate.md
       - UI Themes: Tools and Customisation/ui-themes.md
+  - Changelogs: Tools and Customisation/changelogs.md


### PR DESCRIPTION
Description: This PR just moves the changelogs page below the 'Tools & Customisation' category rather than inside it.