### PR TITLE
Make sure codeblocks are not inside of code

### DIFF
--- a/docs/en/Server Docs/Endpoints/waypoint.md
+++ b/docs/en/Server Docs/Endpoints/waypoint.md
@@ -16,9 +16,9 @@ channel:journeymap:waypoint
 Packet Buffer
 
 ```text
-<code>waypoint StringUtf</code>  value -> waypointjson.toString();
-<code>action StringUtf</code>  value-> "create" or "delete"
-<code>announce Boolean</code> -> value true or false  : Announce determines if the user is notified when a waypoint is created or deleted. 
+waypoint StringUtf  value -> waypointjson.toString();
+action StringUtf  value-> "create" or "delete"
+announce Boolean -> value true or false  : Announce determines if the user is notified when a waypoint is created or deleted. 
 ```
 
 Packet Reader (journeymap's client code)


### PR DESCRIPTION
Description: This PR just fixes an issue where codeblocks were inside of code.

This PR will be backported to 5.8.5 only, since 5.7.1 did not have waypoint command docs.