### PR TITLE
Backport changes about making sure codeblocks are not inside of code

### DIFF
--- a/docs/en/Server Docs/Endpoints/waypoint.md
+++ b/docs/en/Server Docs/Endpoints/waypoint.md
@@ -16,9 +16,9 @@ channel:journeymap:waypoint
 Packet Buffer
 
 ```text
-<code>waypoint StringUtf</code>  value -> waypointjson.toString();
-<code>action StringUtf</code>  value-> "create" or "delete"
-<code>announce Boolean</code> -> value true or false  : Announce determines if the user is notified when a waypoint is created or deleted. 
+waypoint StringUtf  value -> waypointjson.toString();
+action StringUtf  value-> "create" or "delete"
+announce Boolean -> value true or false  : Announce determines if the user is notified when a waypoint is created or deleted. 
 ```
 
 Packet Reader (journeymap's client code)


### PR DESCRIPTION
Description: This PR is just a backport from 5.9.x where it fixes an issue that codeblocks were inside of code.