### PR TITLE
Make sure to use markdown instead of HTML for codeblocks and add changelogs

### DIFF
--- a/docs/en/Tools and Customisation/topographic.md
+++ b/docs/en/Tools and Customisation/topographic.md
@@ -22,7 +22,7 @@ So, given a **world height of 256** blocks, a palette of **32 colors** will crea
 
 ## **Customization**
 
-The topographic maps config file </code>.minecraft/journeymap/config/5.2/journeymap.topo.config</code> can be edited with a simple text editor.  You can make changes to it, save it, and see the results immediately in JourneyMap without a need to restart.
+The topographic maps config file `.minecraft/journeymap/config/5.2/journeymap.topo.config` can be edited with a simple text editor.  You can make changes to it, save it, and see the results immediately in JourneyMap without a need to restart.
 
 The file has the following properties:
 

--- a/docs/en/changelogs.md
+++ b/docs/en/changelogs.md
@@ -1,6 +1,12 @@
 # **Changelogs**
 
-This page shows all the changelogs from JourneyMap 5.9.0 to 5.9.20 which is the latest version of JourneyMap so far.
+This page shows all the changelogs from JourneyMap 5.9.0 to 5.9.21 which is the latest version of JourneyMap so far.
+
+## **JourneyMap 5.9.21**
+
+- Fixed: [ModCompat] ViveCraft key bindings.
+- Fixed: Minimap rendering logic bug.
+- Fixed: Removed some unnecessary class allocations that can have a severe impact on performance.
 
 ## **JourneyMap 5.9.20**
 


### PR DESCRIPTION
Description: This PR just fixes an occasion where I forgot to use markdown instead of HTML for codeblocks. This PR also adds the JourneyMap 5.9.21 changelog.