### PR TITLE
Fix broken mkdocs index page

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,22 +10,22 @@ If you’d like a featureful, easy-to-use mapping mod then why not give JourneyM
 
 ## **First Steps**
 
-- [Download JourneyMap](Client Docs/installing.md)
-- [Use the Options Manager](Client Docs/settings/overview.md)
-- [Share Waypoints](Client Docs/waypoints.md/#sharing-waypoints)
-- [Get Support](About/support.md)
+- [Download JourneyMap](client/installing)
+- [Use the Options Manager](client/settings/overview)
+- [Share Waypoints](client/waypoints/#sharing-waypoints)
+- [Get Support](about/support)
 
 ## **Learn More**
 
-- [Use Keyboard Shortcuts (Keybindings)](Client Docs/basic-usage.md/#key-mappings)
-- [Customize Topographic Maps](Tools and Customisation/topographic.md)
-- [Map a multiplayer server](Tools and Customisation/multiplayer-server.md)
-- [Generate custom-scale maps](Tools and Customisation/journeymap-tools.md)
+- [Use Keyboard Shortcuts (Keybindings)](client/basic-usage/#key-mappings)
+- [Customize Topographic Maps](tools/topographic)
+- [Map a multiplayer server](tools/multiplayer-server)
+- [Generate custom-scale maps](tools/journeymap-tools)
 
 ## **Advanced Topics**
 
-- [Use in a Modpack](About/licensing.md)
-- [Integrate your mod](Tools and Customisation/integration.md)
-- [Make custom mob Icons](Tools and Customisation/custom-mob-icons.md)
-- [Create a UI Theme (Skin)](Tools and Customisation/ui-themes.md)
-- [Translate JourneyMap For Your Language](Contributing/translate-mod.md)
+- [Use in a Modpack](about/licensing)
+- [Integrate your mod](tools/integration)
+- [Make custom mob Icons](tools/custom-mob-icons)
+- [Create a UI Theme (Skin)](tools/ui-themes)
+- [Translate JourneyMap For Your Language](contributing/translate-mod)

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -10,22 +10,22 @@ Si deseas un mod de mapeo con funciones y fácil de usar, ¿por qué no pruebas 
 
 ## **Primeros Pasos**
 
-- [Descargar JourneyMap](Client Docs/installing.md)
-- [Usar el Administrador de opciones](Client Docs/settings/overview.md)
-- [Compartir puntos de ruta](Client Docs/waypoints.md/#compartir-puntos-de-ruta)
-- [Obtener soporte](About/support.md)
+- [Descargar JourneyMap](client/installing)
+- [Usar el Administrador de opciones](client/settings/overview)
+- [Compartir puntos de ruta](client/waypoints/#compartir-puntos-de-ruta)
+- [Obtener soporte](about/support)
 
 ## **Más Información**
 
-- [Usar atajos de teclado (combinaciones de teclas)](Client Docs/basic-usage.md/#asignaciones-de-teclas)
-- [Personalizar mapas topográficos](Tools and Customisation/topographic.md)
-- [Asignar un servidor multijugador](Tools and Customisation/multiplayer-server.md)
-- [Generar mapas a escala personalizada](Tools and Customisation/journeymap-tools.md)
+- [Usar atajos de teclado (combinaciones de teclas)](client/basic-usage/#asignaciones-de-teclas)
+- [Personalizar mapas topográficos](tools/topographic)
+- [Asignar un servidor multijugador](tools/multiplayer-server)
+- [Generar mapas a escala personalizada](tools/journeymap-tools)
 
 ## **Temas Avanzados**
 
-- [Usar en un Modpack](About/licensing.md)
-- [Integra tu mod](Tools and Customisation/integration.md)
-- [Crear íconos de mob personalizados](Tools and Customisation/custom-mob-icons.md)
-- [Crear un tema de interfaz de usuario (máscara)](Tools and Customisation/ui-themes.md)
-- [Traduce JourneyMap para tu idioma](Contributing/translate-mod.md)
+- [Usar en un Modpack](about/licensing)
+- [Integra tu mod](tools/integration)
+- [Crear íconos de mob personalizados](tools/custom-mob-icons)
+- [Crear un tema de interfaz de usuario (máscara)](tools/ui-themes)
+- [Traduce JourneyMap para tu idioma](contributing/translate-mod)

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -10,22 +10,22 @@ Si vous souhaitez un mod de cartographie riche en fonctionnalités et facile à 
 
 ## **Premiers Pas**
 
--   [Télécharger JourneyMap](Client Docs/installing.md)
--   [Utiliser le Gestionnaire d'Options](Client Docs/settings/overview.md)
--   [Partager des Points de Repère](Client Docs/waypoints.md/#sharing-waypoints)
--   [Obtenir de l'Aide](About/support.md)
+-   [Télécharger JourneyMap](client/installing)
+-   [Utiliser le Gestionnaire d'Options](client/settings/overview)
+-   [Partager des Points de Repère](client/waypoints/#sharing-waypoints)
+-   [Obtenir de l'Aide](about/support)
 
 ## **En Savoir Plus**
 
--   [Utiliser les Raccourcis Clavier (Keybindings)](Client Docs/basic-usage.md/#key-mappings)
--   [Personnaliser les Cartes Topographiques](Tools and Customisation/topographic.md)
--   [Cartographier un serveur multijoueur](Tools and Customisation/multiplayer-server.md)
--   [Générer des cartes à l'échelle personnalisée](Tools and Customisation/journeymap-tools.md)
+-   [Utiliser les Raccourcis Clavier (Keybindings)](client/basic-usage/#key-mappings)
+-   [Personnaliser les Cartes Topographiques](tools/topographic)
+-   [Cartographier un serveur multijoueur](tools/multiplayer-server)
+-   [Générer des cartes à l'échelle personnalisée](tools/journeymap-tools)
 
 ## **Sujets Avancés**
 
--   [Utilisation dans un Modpack](About/licensing.md)
--   [Intégrer votre mod](Tools and Customisation/integration.md)
--   [Créer des icônes de mobs personnalisées](Tools and Customisation/custom-mob-icons.md)
--   [Créer un Thème d'Interface Utilisateur (Skin)](Tools and Customisation/ui-themes.md)
--   [Traduire JourneyMap dans votre langue](Contributing/translate-mod.md)
+-   [Utilisation dans un Modpack](about/licensing)
+-   [Intégrer votre mod](tools/integration)
+-   [Créer des icônes de mobs personnalisées](tools/custom-mob-icons)
+-   [Créer un Thème d'Interface Utilisateur (Skin)](tools/ui-themes)
+-   [Traduire JourneyMap dans votre langue](contributing/translate-mod)


### PR DESCRIPTION
Found the broken page from curseforge: https://www.curseforge.com/minecraft/mc-mods/journeymap

Tiny Fix TL;DR
- It seems the docs were recently refactored
- the main page was not updated...rest of the pages seem to work fine